### PR TITLE
Implement device info info the Analytics Identification

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "stable",
+  "flavors": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ build/
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+
+# FVM
+/.fvm/flutter_sdk
+.fvm/flutter_sdk

--- a/lib/src/analytics_identification.dart
+++ b/lib/src/analytics_identification.dart
@@ -1,3 +1,8 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+
 class AnalyticsIdentification {
   String? userId;
   String? deviceId;
@@ -9,4 +14,56 @@ class AnalyticsIdentification {
   String? deviceManufacturer;
   String? deviceModel;
   Map<String, dynamic>? userProperties;
+
+  static Future<AnalyticsIdentification> identifyDevice() async {
+    AnalyticsIdentification properties = AnalyticsIdentification();
+    properties.platform = Platform.operatingSystem;
+
+    DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
+    if (kIsWeb) {
+      WebBrowserInfo info = await deviceInfo.webBrowserInfo;
+      properties.osName = info.appName;
+      properties.osVersion = Platform.operatingSystemVersion;
+      properties.deviceManufacturer = info.vendor;
+      properties.deviceId = 'unknown_web_device_id';
+    } else {
+      try {
+        if (Platform.isMacOS) {
+          MacOsDeviceInfo info = await deviceInfo.macOsInfo;
+          properties.osName = info.hostName;
+          properties.osVersion = info.osRelease;
+          properties.deviceId = 'unknown_macos_device_id';
+          properties.deviceManufacturer = 'Apple';
+          properties.deviceModel = info.model;
+        } else if (Platform.isIOS) {
+          IosDeviceInfo iosInfo = await deviceInfo.iosInfo;
+          properties.osName = iosInfo.systemName;
+          properties.osVersion = iosInfo.systemVersion;
+          properties.deviceId = iosInfo.identifierForVendor;
+          properties.deviceManufacturer = 'Apple';
+          properties.deviceModel = iosInfo.utsname.machine;
+          properties.deviceBrand = iosInfo.localizedModel;
+        } else if (Platform.isAndroid) {
+          AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
+          properties.osName = androidInfo.version.codename;
+          properties.osVersion = androidInfo.version.release;
+          properties.deviceId = androidInfo.id;
+          properties.deviceManufacturer = androidInfo.manufacturer;
+          properties.deviceBrand = androidInfo.brand;
+          properties.deviceModel = androidInfo.model;
+        } else if (Platform.isLinux) {
+          LinuxDeviceInfo info = await deviceInfo.linuxInfo;
+          properties.osName = info.prettyName;
+          properties.osVersion = info.versionId;
+          properties.deviceId = info.machineId;
+        } else {
+          properties.deviceId = 'unknown_device_id';
+        }
+      } catch (e) {
+        properties.deviceId = 'unknown_device_id';
+      }
+    }
+
+    return properties;
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -426,7 +426,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -468,7 +468,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ author:
 homepage:
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=1.17.0'
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0"
 
 dependencies:
   flutter:

--- a/test/analytics_identification_test.dart
+++ b/test/analytics_identification_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_app_analytics/flutter_app_analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('fetchDeviceInfo', () {
+    test('fetches the identity for the current device', () async {
+      final properites = await AnalyticsIdentification.identifyDevice();
+      expect(properites.platform, isNot(null));
+    });
+  });
+}


### PR DESCRIPTION
This implements fetching device info for iOS, Android, macOS, Linux and
Web. Windows does not return anything we need so it was omitted. The
platform value is set via Dart so that will always be present.

[changelog]
added: Added a helper method to get the Device Info

ps-id: 976D2E13-38C5-4F84-A1EA-3E09E36A6FB6