### PR TITLE
Address issues with the Platform OS for Web

### DIFF
--- a/lib/src/analytics_identification.dart
+++ b/lib/src/analytics_identification.dart
@@ -17,7 +17,6 @@ class AnalyticsIdentification {
 
   static Future<AnalyticsIdentification> identifyDevice() async {
     AnalyticsIdentification properties = AnalyticsIdentification();
-    properties.platform = Platform.operatingSystem;
 
     DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
     if (kIsWeb) {
@@ -26,8 +25,11 @@ class AnalyticsIdentification {
       properties.osVersion = Platform.operatingSystemVersion;
       properties.deviceManufacturer = info.vendor;
       properties.deviceId = 'unknown_web_device_id';
+      properties.platform = 'web';
     } else {
       try {
+        properties.platform = Platform.operatingSystem;
+
         if (Platform.isMacOS) {
           MacOsDeviceInfo info = await deviceInfo.macOsInfo;
           properties.osName = info.hostName;


### PR DESCRIPTION
Dart/Flutter has issues with the Platform and determining the OS with
the `Platform.operatingSystem` getter. For web, we just define the
platform as web.

ps-id: DC7B54C2-8351-4B7A-A6C7-336AB5844F63